### PR TITLE
Added new mode to compute slices incrementally for depth texture

### DIFF
--- a/blue_noise.cpp
+++ b/blue_noise.cpp
@@ -6,6 +6,14 @@
 
 #include <chrono>
 #include <sstream>
+#include <iomanip>
+
+BlueNoiseGeneratorParameters params;
+BlueNoiseGenerator generator;
+
+
+std::vector<float> InvertTex3DXZ(const std::vector<float> &tex, const BlueNoiseGeneratorParameters &params);
+void OutputDebugTex3D(const std::vector<float> &blueNoise, const BlueNoiseGeneratorParameters &params, const std::string &filenameFront, const std::string &filenameSide);
 
 class CBlueNoiseGenProgress : public IBlueNoiseGenProgressMonitor
 {
@@ -20,93 +28,212 @@ private:
 	size_t                      currPercent;
 
 private:
-	virtual void OnProgress(size_t iterCount, float bestScore) override
-	{
-		size_t newPercent = size_t(double(iterCount) / (double(numIterationsToFindDistribution) / 100.0));
-		if (iterCount > 0 && newPercent != currPercent)
-		{
-			currPercent = newPercent;
-			milliseconds time_ms = GetCurrentTimeInMs();
-			milliseconds elapsed = time_ms - time_start_ms;
-			float pct = static_cast<float>(iterCount) / static_cast<float>(numIterationsToFindDistribution);
-			float est_remain = static_cast<float>(elapsed.count()) / pct * (1 - pct);
-			est_remain /= 1000.0f;
-			// concatenate into a single stream to avoid multithreading problems
-			std::ostringstream outString;
-			outString << iterCount << "/" << numIterationsToFindDistribution << " best score: " << bestScore << " eta: " << static_cast<int>(est_remain) << " s. " << "elapsed = " << elapsed.count() / 1000.f << " s.";
-			outString << " (" << (static_cast<int>(est_remain) / (60 * 60)) << " h " << (static_cast<int>(est_remain / 60) % 60) << " m " << (static_cast<int>(est_remain) % 60) << " s)";
-			outString << std::endl;
-			std::cout << outString.str();
-		}
-	}
-	virtual void OnStartWhiteNoiseGeneration() override
-	{
-		// no-op
-	}
-	virtual void OnStartBlueNoiseGeneration() override
-	{
-		time_start_ms = GetCurrentTimeInMs();
-	}
-	static milliseconds GetCurrentTimeInMs()
-	{
-		return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch());
-	}
+	static std::string SecondsToHumanReadable(float seconds);
+	static milliseconds GetCurrentTimeInMs();
+	//
+	virtual void OnProgress(size_t iterCount, double bestScore, size_t swapCount, size_t swapAttempt) override;
+	virtual void OnStartWhiteNoiseGeneration() override;
+	virtual void OnStartBlueNoiseGeneration() override;
+	virtual void OnSliceGenerated(size_t sliceIndex, size_t totalSliceCount) override;
+	virtual void OnSliceRefined(size_t sliceIndex, size_t totalSliceCount) override;
 };
-
 
 int main(int argc, char** argv)
 {
-	BlueNoiseGeneratorParameters params;
+
+	// 2D Texture example
 	params.chosenMethod = BlueNoiseGeneratorParameters::Method_SolidAngle;
-	//params.chosenMethod = BlueNoiseGeneratorParameters::Method_HighPass;
 	params.N_dimensions = 2u;
-	params.dimensionSize[0] = 32;
-	params.dimensionSize[1] = 32;
+	params.dimensionSize[0] = 128;
+	params.dimensionSize[1] = 128;
 	params.dimensionSize[2] = 0;
 	params.dimensionSize[3] = 0;
 	params.N_valuesPerItem = 1u;
 	params.useMultithreading = true;
 	params.useIncrementalUpdate = true; // required for multithreading
-	params.numIterationsToFindDistribution = 256 * 1024;
+	params.numIterationsToFindDistribution = 4 * 256 * 1024;
+
+
+	// 3D Texture example : use no wrap for Z and progressive approach with BlueNoiseGeneratorParameters::Method_IndependantSlices (otherwise very slow, and do not converge well)
+	/*params.chosenMethod = BlueNoiseGeneratorParameters::Method_IndependantSlices;
+	params.N_dimensions = 3u;
+	params.dimensionSize[0] = 128;
+	params.dimensionSize[1] = 128;
+	params.dimensionSize[2] = 8;
+	params.dimensionSize[3] = 0;
+	params.N_valuesPerItem = 1u;
+	params.useMultithreading = true;
+	params.useIncrementalUpdate = true; // required for multithreading
+	params.numIterationsToFindDistribution = 256 * 1024;*/
 
 	std::vector<float> whiteNoise;
 	std::vector<float> blueNoise;
-
 	CBlueNoiseGenProgress progress(params.numIterationsToFindDistribution);
-	BlueNoiseGenerator generator;
-	generator.GenerateBlueNoise(params, whiteNoise, blueNoise, &progress);
-
-
-	BlueNoiseExportUtil::SaveAsPPM(whiteNoise, "white_noise.ppm", params.dimensionSize, params.N_dimensions, params.N_valuesPerItem);
-	//BlueNoiseExportUtil::SaveAsBMP(whiteNoise, "white_noise.bmp", params.dimensionSize, params.N_valuesPerItem);
-	BlueNoiseExportUtil::SaveAsPPM(blueNoise, "blue_noise.ppm", params.dimensionSize, params.N_dimensions, params.N_valuesPerItem);
-
-	// debugging code for output 3D texture
-	// front
-/*	for (size_t z = 0u; z < params.dimensionSize[2]; ++z)
+	BlueNoiseGenerator::EResult result = generator.GenerateBlueNoise(params, whiteNoise, blueNoise, &progress);
+	switch (result)
 	{
-		char buf[512];
-		sprintf(buf, "blue_noise_z%u.ppm", z);
-		BlueNoiseExportUtil::SaveAsPPM(blueNoise, buf, params.dimensionSize, params.N_dimensions, params.N_valuesPerItem, uint32_t(z));
+	case BlueNoiseGenerator::Result_DimensionSmallerThanKernelSize:
+		std::cout << "Texture dimension must be greater or equal than " << generator.GetMinTextureSize() << " texels." << std::endl;
+		getchar();
+		return -1;
+		break;
 	}
-	// side
-	std::vector<float> sidePattern(blueNoise.size());
-	for (size_t z = 0u; z < params.dimensionSize[2]; ++z)
+	BlueNoiseExportUtil::SaveAsPPM(whiteNoise, "mt_white_noise.ppm", params.dimensionSize, params.N_dimensions, params.N_valuesPerItem);
+	BlueNoiseExportUtil::SaveAsPPM(blueNoise, "mt_blue_noise.ppm", params.dimensionSize, params.N_dimensions, params.N_valuesPerItem);
+	BlueNoiseExportUtil::PrintCodeOutput("noise.txt", blueNoise, "BlueNoise", false, params.dimensionSize, params.N_dimensions, params.N_valuesPerItem);
+}
+
+std::vector<float> InvertTex3DXZ(const std::vector<float> &tex, const BlueNoiseGeneratorParameters &params)
+{
+	size_t		swappedDimensionSize[BlueNoiseGeneratorParameters::max_N_dimensions];
+	swappedDimensionSize[0] = params.dimensionSize[2];
+	swappedDimensionSize[1] = params.dimensionSize[1];
+	swappedDimensionSize[2] = params.dimensionSize[0];
+
+	std::vector<float> sidePattern(tex.size());
+	for (size_t z = 0u; z < swappedDimensionSize[2]; ++z)
 	{
-		for (size_t y = 0u; y < params.dimensionSize[1]; ++y)
+		for (size_t y = 0u; y < swappedDimensionSize[1]; ++y)
 		{
-			for (size_t x = 0u; x < params.dimensionSize[0]; ++x)
+			for (size_t x = 0u; x < swappedDimensionSize[0]; ++x)
 			{
-				sidePattern[z * (params.dimensionSize[0] * params.dimensionSize[1]) + y * params.dimensionSize[0] + x] = blueNoise[x * (params.dimensionSize[0] * params.dimensionSize[1]) + y * params.dimensionSize[0] + z];
+				for (size_t itemValueIndex = 0; itemValueIndex < params.N_valuesPerItem; ++itemValueIndex)
+				{
+					const float srcValue = tex[params.N_valuesPerItem * (x * (params.dimensionSize[0] * params.dimensionSize[1]) + y * params.dimensionSize[0] + z) + itemValueIndex];
+					sidePattern[params.N_valuesPerItem * (z * (swappedDimensionSize[0] * swappedDimensionSize[1]) + y * swappedDimensionSize[0] + x) + itemValueIndex] = srcValue;
+				}
 			}
 		}
 	}
+	return sidePattern;
+}
 
-	for (size_t z = 0u; z < params.dimensionSize[2]; ++z)
+void OutputDebugTex3D(const std::vector<float> &blueNoise, const BlueNoiseGeneratorParameters &params, const std::string &filenameFront, const std::string &filenameSide)
+{
+	// debugging code for output 3D texture
+	// front
+	if (params.N_dimensions == 3)
 	{
-		char buf[512];
-		sprintf(buf, "blue_noise_side_z%u.ppm", z);
-		BlueNoiseExportUtil::SaveAsPPM(sidePattern, buf, params.dimensionSize, params.N_dimensions, params.N_valuesPerItem, uint32_t(z));
+		for (size_t z = 0u; z < params.dimensionSize[2]; ++z)
+		{
+			char buf[512];
+			sprintf(buf, "%s_z%u.ppm", filenameFront.c_str(), z);
+			BlueNoiseExportUtil::SaveAsPPM(blueNoise, buf, params.dimensionSize, params.N_dimensions, params.N_valuesPerItem, uint32_t(z));
+		}
+		// side
+		size_t		swappedDimensionSize[BlueNoiseGeneratorParameters::max_N_dimensions];
+		swappedDimensionSize[0] = params.dimensionSize[2];
+		swappedDimensionSize[1] = params.dimensionSize[1];
+		swappedDimensionSize[2] = params.dimensionSize[0];
+
+		std::vector<float> sidePattern = InvertTex3DXZ(blueNoise, params);
+
+		for (size_t z = 0u; z < params.dimensionSize[2]; ++z)
+		{
+			char buf[512];
+			sprintf(buf, "%s_z%u.ppm", filenameSide.c_str(), z);
+			BlueNoiseExportUtil::SaveAsPPM(sidePattern, buf, swappedDimensionSize, params.N_dimensions, params.N_valuesPerItem, uint32_t(z));
+		}
+	}
+}
+
+std::string CBlueNoiseGenProgress::SecondsToHumanReadable(float seconds)
+{
+	std::ostringstream outString;
+	int im = static_cast<int>(seconds);
+	outString << " (" << (im / (60 * 60)) << " h " << ((im / 60) % 60) << " m " << (im % 60) << " s)";
+	return outString.str();
+}
+void CBlueNoiseGenProgress::OnProgress(size_t iterCount, double bestScore, size_t swapCount, size_t swapAttempt)
+{
+	size_t newPercent = size_t(double(iterCount) / (double(numIterationsToFindDistribution) / 100.0));
+	if (iterCount > 0 && newPercent != currPercent)
+	{
+		currPercent = newPercent;
+		milliseconds time_ms = GetCurrentTimeInMs();
+		milliseconds elapsed = time_ms - time_start_ms;
+		float pct = static_cast<float>(iterCount) / static_cast<float>(numIterationsToFindDistribution);
+		float est_remain = static_cast<float>(elapsed.count()) / pct * (1 - pct);
+		est_remain /= 1000.0f;
+		// concatenate into a single stream to avoid multithreading problems
+		std::ostringstream outString;
+		outString << iterCount << "/" << numIterationsToFindDistribution << " best score: " << bestScore << " eta: " << static_cast<int>(est_remain) << " s. " << "elapsed = " << elapsed.count() / 1000.f << " s.";
+		outString << SecondsToHumanReadable(est_remain);
+		//outString << "swap ratio : " << (double)swapCount / swapAttempt;
+		outString << std::endl;
+		std::cout << outString.str();
+		//
+		/*{
+		std::vector<float> blueNoise;
+		generator.GetCurrentBlueNoise(blueNoise);
+		static int count = 0;
+		std::ostringstream name;
+		name << "mt_blue_noise_" << std::setfill('0') << std::setw(5) << count << ".ppm";
+		BlueNoiseExportUtil::SaveAsPPM(blueNoise, name.str(), params.dimensionSize, params.N_dimensions, params.N_valuesPerItem);
+		++count;
+		//OutputDebugTex3D(blueNoise, params, "mt_blue_noise_front", "mt_blue_noise_side");
+		}*/
+	}
+}
+void CBlueNoiseGenProgress::OnStartWhiteNoiseGeneration()
+{
+	std::cout << "Blue noise generation started ..." << std::endl;
+	// no-op
+}
+void CBlueNoiseGenProgress::OnStartBlueNoiseGeneration()
+{
+	time_start_ms = GetCurrentTimeInMs();
+}
+CBlueNoiseGenProgress::milliseconds CBlueNoiseGenProgress::GetCurrentTimeInMs()
+{
+	return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch());
+}
+void CBlueNoiseGenProgress::OnSliceGenerated(size_t sliceIndex, size_t totalSliceCount)
+{
+	std::cout << sliceIndex << "/" << totalSliceCount << std::endl;
+}
+void CBlueNoiseGenProgress::OnSliceRefined(size_t sliceIndex, size_t totalSliceCount)
+{
+	// no-op
+	if (sliceIndex != 0)
+	{
+		milliseconds time_ms = GetCurrentTimeInMs();
+		milliseconds elapsed = time_ms - time_start_ms;
+		float pct = static_cast<float>(sliceIndex) / static_cast<float>(totalSliceCount);
+		float est_remain = static_cast<float>(elapsed.count()) / pct * (1 - pct);
+		est_remain /= 1000.0f;
+		// concatenate into a single stream to avoid multithreading problems
+		std::ostringstream outString;
+		outString << "(" << sliceIndex << "/" << totalSliceCount << ") ";
+		outString << " eta: " << static_cast<int>(est_remain) << " s. " << "elapsed = " << elapsed.count() / 1000.f << " s.";
+		outString << SecondsToHumanReadable(est_remain);
+		outString << std::endl;
+		std::cout << outString.str();
+	}
+	/*{
+		std::ostringstream name;
+		name << "mt_blue_noise_slice_" << std::setfill('0') << std::setw(5) << sliceIndex << ".ppm";
+		std::vector<float> blueNoise;
+		generator.GetCurrentBlueNoise(blueNoise);
+		BlueNoiseExportUtil::SaveAsPPM(blueNoise, name.str(), params.dimensionSize, params.N_dimensions, params.N_valuesPerItem, sliceIndex);
+	}
+	{
+		std::ostringstream name;
+		name << "mt_blue_noise_slice_side_" << std::setfill('0') << std::setw(5) << sliceIndex << ".ppm";
+		std::vector<float> blueNoise;
+		generator.GetCurrentBlueNoise(blueNoise);
+
+		size_t		swappedDimensionSize[BlueNoiseGeneratorParameters::max_N_dimensions];
+		swappedDimensionSize[0] = params.dimensionSize[2];
+		swappedDimensionSize[1] = params.dimensionSize[1];
+		swappedDimensionSize[2] = params.dimensionSize[0];
+
+		BlueNoiseExportUtil::SaveAsPPM(InvertTex3DXZ(blueNoise, params), name.str(), swappedDimensionSize, params.N_dimensions, params.N_valuesPerItem, 0);
 	}*/
 
+	/*std::ostringstream name;
+	name << "mt_blue_noise_slice_" << std::setfill('0') << std::setw(5) << sliceIndex << ".ppm";
+	std::vector<float> blueNoise;
+	generator.GetCurrentBlueNoise(blueNoise);
+	BlueNoiseExportUtil::SaveAsPPM(blueNoise, name.str(), params.dimensionSize, params.N_dimensions, params.N_valuesPerItem);*/
 }

--- a/blue_noise_export_util.cpp
+++ b/blue_noise_export_util.cpp
@@ -131,7 +131,7 @@ void BlueNoiseExportUtil::PrintCodeOutput (const std::string&			fileName,
 		outFile << "static const float " << arrName;
 		for (size_t d = 0; d < N_dimensions; ++d)
 		{
-			outFile << "[" << dimensionSize[d] << "]";
+			outFile << "[" << dimensionSize[N_dimensions - 1 - d] << "]";
 		}
 		if (N_valuesPerItem > 1)
 		{
@@ -155,14 +155,14 @@ void BlueNoiseExportUtil::PrintCodeOutput (const std::string&			fileName,
 		}
 		if (N_valuesPerItem == 1)
 		{
-			outFile << std::setprecision(8) << std::fixed << arr[i];
+			outFile << std::setprecision(8) << std::fixed << arr[i] << "f";
 		}
 		else
 		{
 			outFile << "{";
 			for (size_t v = 0; v < N_valuesPerItem; ++v)
 			{
-				outFile << std::setprecision(8) << std::fixed << arr[i * N_valuesPerItem + v];
+				outFile << std::setprecision(8) << std::fixed << arr[i * N_valuesPerItem + v] << "f";
 				if (v < N_valuesPerItem - 1)
 				{
 					outFile << ", ";

--- a/blue_noise_generator.h
+++ b/blue_noise_generator.h
@@ -11,8 +11,13 @@ struct IBlueNoiseGenProgressMonitor
 {
 	virtual void OnStartWhiteNoiseGeneration() = 0;
 	virtual void OnStartBlueNoiseGeneration() = 0;
-	virtual void OnProgress(size_t iterCount, float bestScore) = 0;
+	virtual void OnProgress(size_t iterCount, double bestScore, size_t swapCount, size_t swapAttempt) = 0;
+	virtual void OnSliceGenerated(size_t sliceIndex, size_t totalSliceCount) = 0;
+	virtual void OnSliceRefined(size_t sliceIndex, size_t totalSliceCount) = 0;
 };
+
+
+typedef float Real;
 
 class BlueNoiseGenerator
 {
@@ -29,6 +34,7 @@ public:
 								std::vector<float>					&blueNoiseResult,
 								IBlueNoiseGenProgressMonitor		*progressMonitor = nullptr);
 	static uint32_t GetMinTextureSize();
+	void GetCurrentBlueNoise(std::vector<float> &dest) const;
 private:
 	class BlueNoiseGeneratorImpl *pImpl;
 };

--- a/blue_noise_generator_parameters.cpp
+++ b/blue_noise_generator_parameters.cpp
@@ -12,5 +12,6 @@ BlueNoiseGeneratorParameters::BlueNoiseGeneratorParameters()
 	useMultithreading					= true;
 	useIncrementalUpdate				= true;
 	numIterationsToFindDistribution		= 256 * 1024;
+	refineSpecificSlice = -1;
 }
 

--- a/blue_noise_generator_parameters.h
+++ b/blue_noise_generator_parameters.h
@@ -2,6 +2,7 @@
 #define BLUE_NOISE_GENERATOR_PARAMETERS_H
 
 #include "config.h"
+#include <stdint.h>
 
 class BlueNoiseGeneratorParameters
 {
@@ -9,8 +10,10 @@ public:
 	static const size_t max_N_dimensions = 4;
 	enum EMethod
 	{
+		Method_WhiteNoise,
 		Method_SolidAngle,
-		Method_HighPass,
+		Method_IndependantSlices,
+		Method_HighPass
 	};
 	//
 	EMethod			chosenMethod;
@@ -20,6 +23,7 @@ public:
 	bool			useMultithreading;
 	bool			useIncrementalUpdate; // required for multithreading
 	size_t			numIterationsToFindDistribution;
+	int32_t			refineSpecificSlice;
 public:
 	// ctor with default values
 	BlueNoiseGeneratorParameters();

--- a/config.h
+++ b/config.h
@@ -2,9 +2,10 @@
 #define CONFIG_H
 
 // settings
-#define USE_SSE
-#define USE_FAST_POW_SSE
-#define USE_FAST_EXP
+// SSE ok for 2D textures, but too imprecise for 3D
+//#define USE_SSE
+//#define USE_FAST_POW_SSE
+//#define USE_FAST_EXP
 #define USE_FAST_MODULO
 #define USE_FAST_DIV
 

--- a/math_util.h
+++ b/math_util.h
@@ -13,7 +13,12 @@ inline size_t	IntPow(size_t base, size_t exp);
 inline int		FastModulo(int dividand, int divisor);
 inline int		FastDiv(int dividand, int divisor);
 inline float	FastPowScalar(float value, float exponent);
-inline float	FastExp(double x);
+inline double	FastPowScalar(double value, double exponent);
+inline double	FastExp(double x);
+inline float	Clamp(float value, float v0, float v1) { return std::max(v0, std::min(v1, value)); }
+inline float    Saturate(float value) { return Clamp(value, 0.f, 1.f);  }
+
+inline double Sqr(double val) { return val * val;  }
 
 #include "math_util.inl"
 #undef MATH_UTIL_INCLUDE_START

--- a/math_util.inl
+++ b/math_util.inl
@@ -77,11 +77,16 @@ inline float FastPowScalar(float value, float exponent)
 #endif
 }
 
+inline double	FastPowScalar(double value, double exponent)
+{
+	return pow(value, exponent);
+}
+
 // from https://codingforspeed.com/using-faster-exponential-approximation/
-inline float FastExp(double x)
+inline float FastExp(float x)
 {
 #ifdef USE_FAST_EXP
-	x = x / 1024 + 1.0;
+	x = x / 1024.f + 1.f;
 	x *= x;
 	x *= x;
 	x *= x;
@@ -94,8 +99,13 @@ inline float FastExp(double x)
 	x *= x;
 	return float(x);
 #else
-	return float(exp(x));
+	return float(expf(x));
 #endif
+}
+
+inline double FastExp(double x)
+{
+	return exp(x);
 }
 
 #endif


### PR DESCRIPTION
- I added a progressive mode to compute 3D textures
It works quite well (slice are losely couples, and look indeed like blue noise)
- I think that the difficulty with 3D textures in general is that the kernel is too big, causing overcoupling, and can't converge easily to blue noise as a result. A future improvement could be to remove samples on the kernel that do not contribute enough (when dz < 0, only keeping samples with x == 0 and y == 0 for example).